### PR TITLE
Issue #32: Missing JRE module jdk.naming.rmi

### DIFF
--- a/modules.txt
+++ b/modules.txt
@@ -23,6 +23,7 @@ jdk.jfr
 jdk.management.agent
 jdk.management.jfr
 jdk.management
+jdk.naming.rmi
 jdk.net
 jdk.security.auth
 jdk.unsupported


### PR DESCRIPTION
## Summary
- include missing `jdk.naming.rmi` module in the module list
- revert README wording change

## Testing
- `jlink --version`
- `java -version`


------
https://chatgpt.com/codex/tasks/task_b_6842ba8bff548332a348959e96a8742a